### PR TITLE
Extra lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist/*
+karma*.js
+webrtc-adapter.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "conaclos/esnext-base",
+    "standard"
+  ],
+  "rules": {
+    "no-shadow": 0
+  },
+  "globals": {
+    "netflux": true,
+    "jasmine": true,
+    "describe": true,
+    "xdescribe": true,
+    "it": true,
+    "xit": true,
+    "expect": true,
+    "beforeEach": true,
+    "afterEach": true,
+    "beforeAll": true,
+    "afterAll": true,
+    "spyOn": true,
+    "DOMException": true,
+    "RTCPeerConnection": true,
+    "RTCSessionDescription": true,
+    "RTCDataChannel": true,
+    "RTCIceCandidate": true,
+    "WebSocket": true,
+    "TextEncoder": true,
+    "TextDecoder": true,
+    "Event": true,
+    "CloseEvent": true
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,15 @@
     "standard"
   ],
   "rules": {
-    "no-shadow": 0
+    "default-case": 0,
+    "no-console": 0,
+    "no-continue": 0,
+    "no-loop-func": 0,
+    "no-param-reassign": 0,
+    "no-shadow": 0,
+    "no-sync": 0,
+    "no-use-before-define": 0,
+    "prefer-const": 0
   },
   "globals": {
     "netflux": true,

--- a/jasmine.conf.js
+++ b/jasmine.conf.js
@@ -1,8 +1,8 @@
 // Configuration for running tests in NodeJS
-let Jasmine = require('jasmine')
-let SpecReporter = require('jasmine-spec-reporter')
+const Jasmine = require('jasmine')
+const SpecReporter = require('jasmine-spec-reporter')
 
-let config = {
+const config = {
   spec_dir: '.rolledupTest',
   spec_files: [
     'unit/**/*.test.js',
@@ -13,7 +13,7 @@ let config = {
   random: false
 }
 
-let jrunner = new Jasmine()
+const jrunner = new Jasmine()
 jrunner.configureDefaultReporter({print: () => {}})    // remove default reporter logs
 jasmine.getEnv().addReporter(new SpecReporter({displaySpecDuration: true}))   // add jasmine-spec-reporter
 jrunner.loadConfig(config)           // load jasmine.json configuration

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test:coverage": "rm -rf coverage && npm run pretest && node jasmine.conf.js && karma start karma.conf.coverage.js",
     "test:travis": "npm run pretest && node jasmine.conf.js && karma start karma.conf.travis.js",
     "commit": "git-cz",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "lint": "eslint ./"
   },
   "dependencies": {
     "text-encoding": "^0.6.0",
@@ -76,38 +77,12 @@
     "rollup-plugin-string": "^2.0.2",
     "semantic-release": "^4.3.5",
     "sigver": "^7.1.0",
-    "standard": "^8.0.0",
-    "uglify-js": "^2.7.3"
-  },
-  "standard": {
-    "globals": [
-      "netflux",
-      "jasmine",
-      "describe",
-      "xdescribe",
-      "it",
-      "xit",
-      "expect",
-      "beforeEach",
-      "afterEach",
-      "beforeAll",
-      "afterAll",
-      "spyOn",
-      "DOMException",
-      "RTCPeerConnection",
-      "RTCSessionDescription",
-      "RTCDataChannel",
-      "RTCIceCandidate",
-      "WebSocket",
-      "TextEncoder",
-      "TextDecoder",
-      "Event",
-      "CloseEvent"
-    ],
-    "ignore": [
-      "dist/*",
-      "karma*.js"
-    ]
+    "uglify-js": "^2.7.3",
+    "eslint": "~3.7.0",
+    "eslint-config-standard": "^6.2.0",
+    "eslint-plugin-standard": "^2.0.0",
+    "eslint-config-conaclos": "~1.2.0",
+    "eslint-plugin-promise": "^2.0.0"
   },
   "config": {
     "ghooks": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
-let rollup = require('rollup')
-let filesize = require('rollup-plugin-filesize')
-let includePaths = require('rollup-plugin-includepaths')
+const rollup = require('rollup')
+const filesize = require('rollup-plugin-filesize')
+const includePaths = require('rollup-plugin-includepaths')
 
 // Build distributions
 rollup.rollup({

--- a/script/botForChrome.js
+++ b/script/botForChrome.js
@@ -1,7 +1,7 @@
 import {create} from 'dist/netflux.es2015.js'
 import {SIGNALING_URL, onMessageForBot} from 'test/util/helper'
 
-let wc = create({signalingURL: SIGNALING_URL})
+const wc = create({signalingURL: SIGNALING_URL})
 wc.onMessage = (id, msg, isBroadcast) => onMessageForBot(wc, id, msg, isBroadcast)
 wc.onClose = closeEvt => {
   console.log('Chrome bot has disconnected from Signaling server')

--- a/script/botForFirefox.js
+++ b/script/botForFirefox.js
@@ -1,7 +1,7 @@
 import {create} from 'dist/netflux.es2015.js'
 import {SIGNALING_URL, onMessageForBot} from 'test/util/helper'
 
-let wc = create({signalingURL: SIGNALING_URL})
+const wc = create({signalingURL: SIGNALING_URL})
 wc.onMessage = (id, msg, isBroadcast) => onMessageForBot(wc, id, msg, isBroadcast)
 wc.onClose = closeEvt => {
   console.log(`Firefox bot has disconnected from Signaling server`)

--- a/script/botForNode.js
+++ b/script/botForNode.js
@@ -1,7 +1,7 @@
 import {create} from 'dist/netflux.es2015.js'
 import {SIGNALING_URL, onMessageForBot} from 'test/util/helper'
 
-let wc = create({signalingURL: SIGNALING_URL})
+const wc = create({signalingURL: SIGNALING_URL})
 wc.onMessage = (id, msg, isBroadcast) => onMessageForBot(wc, id, msg, isBroadcast)
 wc.onClose = closeEvt => {
   console.log(`Node bot has disconnected from Signaling server`)

--- a/script/botServer.js
+++ b/script/botServer.js
@@ -11,13 +11,13 @@ server.start()
       wc.onMessage = (id, msg, isBroadcast) => helper.onMessageForBot(wc, id, msg, isBroadcast)
     }
 
-    let wcSocketChrome = create({signalingURL: helper.SIGNALING_URL})
+    const wcSocketChrome = create({signalingURL: helper.SIGNALING_URL})
     wcSocketChrome.id = helper.CHROME_WC_ID
     wcSocketChrome.onMessage = (id, msg, isBroadcast) => helper.onMessageForBot(wcSocketChrome, id, msg, isBroadcast)
 
     server.addWebChannel(wcSocketChrome)
 
-    let wcSocketFirefox = create({signalingURL: helper.SIGNALING_URL})
+    const wcSocketFirefox = create({signalingURL: helper.SIGNALING_URL})
     wcSocketFirefox.id = helper.FIREFOX_WC_ID
     wcSocketFirefox.onMessage = (id, msg, isBroadcast) => helper.onMessageForBot(wcSocketFirefox, id, msg, isBroadcast)
     server.addWebChannel(wcSocketFirefox)

--- a/script/rollup.config.js
+++ b/script/rollup.config.js
@@ -1,7 +1,7 @@
-let rollup = require('rollup')
-let includePaths = require('rollup-plugin-includepaths')
+const rollup = require('rollup')
+const includePaths = require('rollup-plugin-includepaths')
 
-let entries = [
+const entries = [
   'script/botServer.js',
   'script/botForFirefox.js',
   'script/botForChrome.js',
@@ -9,7 +9,7 @@ let entries = [
 ]
 
 for (let entry of entries) {
-  let dest = entry.replace(/^script/, '.rolledupScript')
+  const dest = entry.replace(/^script/, '.rolledupScript')
   rollup.rollup({
     entry,
     plugins: [

--- a/src/BotServer.js
+++ b/src/BotServer.js
@@ -69,7 +69,7 @@ class BotServer {
    */
   start () {
     return new Promise((resolve, reject) => {
-      let WebSocketServer = require('ws').Server
+      const WebSocketServer = require('ws').Server
       this.server = new WebSocketServer({
         host: this.settings.host,
         port: this.settings.port
@@ -90,9 +90,9 @@ class BotServer {
       this.server.on('connection', ws => {
         ws.onmessage = msgEvt => {
           try {
-            let msg = JSON.parse(msgEvt.data)
+            const msg = JSON.parse(msgEvt.data)
             if ('join' in msg) {
-              let wc = this.getWebChannel(msg.join)
+              const wc = this.getWebChannel(msg.join)
               if (wc === null) {
                 ws.send(JSON.stringify({isKeyOk: false}))
               } else {

--- a/src/BotServer.js
+++ b/src/BotServer.js
@@ -57,15 +57,15 @@ class BotServer {
     this.webChannels = []
 
     /**
-     * @param {WebChannel} wc
+     * @type {function(wc: WebChannel)}
      */
-    this.onWebChannel = wc => {}
+    this.onWebChannel = () => {}
   }
 
   /**
    * Starts listen on socket.
    *
-   * @returns {Promise<, string>}
+   * @returns {Promise<undefined,string>}
    */
   start () {
     return new Promise((resolve, reject) => {
@@ -161,7 +161,7 @@ class BotServer {
   /**
    * Add `WebChannel`.
    *
-   * @param {WebChannel} wc Description
+   * @param {WebChannel} wc
    */
   addWebChannel (wc) {
     this.webChannels[this.webChannels.length] = wc

--- a/src/Channel.js
+++ b/src/Channel.js
@@ -90,7 +90,7 @@ class Channel {
   }
 
   /**
-   * @type {function(message: ArrayBuffer)}
+   * @param {function(msg: ArrayBuffer)} handler
    */
   set onMessage (handler) {
     if (!Util.isBrowser() && Util.isSocket(this.channel)) {
@@ -106,7 +106,7 @@ class Channel {
   }
 
   /**
-   * @type {function(message: CloseEvent)}
+   * @param {function(message: CloseEvent)} handler
    */
   set onClose (handler) {
     this.channel.onclose = closeEvt => {
@@ -118,7 +118,7 @@ class Channel {
   }
 
   /**
-   * @type {function(message: Event)}
+   * @param {function(message: Event)} handler
    */
   set onError (handler) {
     this.channel.onerror = evt => handler(evt)

--- a/src/Channel.js
+++ b/src/Channel.js
@@ -95,8 +95,8 @@ class Channel {
   set onMessage (handler) {
     if (!Util.isBrowser() && Util.isSocket(this.channel)) {
       this.channel.onmessage = msgEvt => {
-        let ab = new ArrayBuffer(msgEvt.data.length)
-        let view = new Uint8Array(ab)
+        const ab = new ArrayBuffer(msgEvt.data.length)
+        const view = new Uint8Array(ab)
         for (let i = 0; i < msgEvt.data.length; i++) {
           view[i] = msgEvt.data[i]
         }
@@ -136,7 +136,7 @@ class Channel {
    * @returns {boolean}
    */
   isOpen () {
-    let state = this.channel.readyState
+    const state = this.channel.readyState
     return state === 1 || state === 'open'
   }
 

--- a/src/SignalingGate.js
+++ b/src/SignalingGate.js
@@ -59,7 +59,7 @@ class SignalingGate {
           ws.onerror = err => reject(err.message)
           ws.onmessage = evt => {
             try {
-              let msg = JSON.parse(evt.data)
+              const msg = JSON.parse(evt.data)
               if ('isKeyOk' in msg) {
                 if (msg.isKeyOk) {
                   ServiceFactory.get(WEB_RTC, this.webChannel.settings.iceServers)

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,4 +1,4 @@
-let NodeCloseEvent = class CloseEvent {
+const NodeCloseEvent = class CloseEvent {
   constructor (options = {}) {
     this.wasClean = options.wasClean
     this.code = options.code
@@ -20,7 +20,7 @@ class Util {
    * @returns {CloseEvent|NodeCloseEvent}
    */
   static createCloseEvent (code, reason = '', wasClean = true) {
-    let obj = {wasClean, code, reason}
+    const obj = {wasClean, code, reason}
     if (Util.isBrowser()) {
       return new CloseEvent('netfluxClose', obj)
     } else {
@@ -67,7 +67,7 @@ class Util {
       '(?:\\S+(?::\\S*)?@)?' +
       '(?:'
 
-    let tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))?'
+    const tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))?'
 
     regex +=
         // IP address dotted notation octets

--- a/src/WebChannel.js
+++ b/src/WebChannel.js
@@ -195,7 +195,7 @@ class WebChannel {
               ws.onclose = closeEvt => reject(closeEvt.reason)
               ws.onmessage = evt => {
                 try {
-                  let msg = JSON.parse(evt.data)
+                  const msg = JSON.parse(evt.data)
                   if ('isKeyOk' in msg) {
                     if (msg.isKeyOk) {
                       if ('useThis' in msg && msg.useThis) {
@@ -253,11 +253,11 @@ class WebChannel {
    * callback function take a parameter of type {@link SignalingGate~AccessData}.
    */
   open (options) {
-    let defaultSettings = {
+    const defaultSettings = {
       url: this.settings.signalingURL,
       key: null
     }
-    let settings = Object.assign({}, defaultSettings, options)
+    const settings = Object.assign({}, defaultSettings, options)
     if (Util.isURL(settings.url)) {
       return this.gate.open(settings.url, dataCh => this.addChannel(dataCh), settings.key)
     } else {
@@ -357,7 +357,7 @@ class WebChannel {
   addChannel (channel) {
     return this.initChannel(channel)
       .then(channel => {
-        let msg = this.msgBld.msg(INITIALIZATION, this.myId, channel.peerId, {
+        const msg = this.msgBld.msg(INITIALIZATION, this.myId, channel.peerId, {
           manager: this.manager.id,
           wcId: this.id
         })
@@ -397,7 +397,7 @@ class WebChannel {
       this.manager.sendInnerTo(recepient, this, data)
     } else {
       if (Number.isInteger(recepient)) {
-        let msg = this.msgBld.msg(INNER_DATA, this.myId, recepient, {serviceId, data})
+        const msg = this.msgBld.msg(INNER_DATA, this.myId, recepient, {serviceId, data})
         this.manager.sendInnerTo(recepient, this, msg)
       } else {
         recepient.send(this.msgBld.msg(INNER_DATA, this.myId, recepient.peerId, {serviceId, data}))
@@ -421,13 +421,13 @@ class WebChannel {
    * @param {external:ArrayBuffer} data - Message
    */
   onChannelMessage (channel, data) {
-    let header = this.msgBld.readHeader(data)
+    const header = this.msgBld.readHeader(data)
     if (header.code === USER_DATA) {
       this.msgBld.readUserMessage(this, header.senderId, data, (fullData, isBroadcast) => {
         this.onMessage(header.senderId, fullData, isBroadcast)
       })
     } else {
-      let msg = this.msgBld.readInternalMessage(data)
+      const msg = this.msgBld.readInternalMessage(data)
       switch (header.code) {
         case INITIALIZATION:
           this.settings.topology = msg.manager
@@ -450,7 +450,7 @@ class WebChannel {
           this.manager.sendTo(header.senderId, this, this.msgBld.msg(PONG, this.myId))
           break
         case PONG:
-          let now = Date.now()
+          const now = Date.now()
           this.pongNb++
           this.maxTime = Math.max(this.maxTime, now - this.pingTime)
           if (this.pongNb === this.members.length) {
@@ -476,7 +476,7 @@ class WebChannel {
    */
   initChannel (ch, id = -1) {
     if (id === -1) id = this.generateId()
-    let channel = new Channel(ch)
+    const channel = new Channel(ch)
     channel.peerId = id
     channel.webChannel = this
     channel.onMessage = data => this.onChannelMessage(channel, data)
@@ -505,7 +505,7 @@ class WebChannel {
    */
   generateId () {
     do {
-      let id = Math.ceil(Math.random() * MAX_ID)
+      const id = Math.ceil(Math.random() * MAX_ID)
       if (id === this.myId) continue
       if (this.members.includes(id)) continue
       if (this.generatedIds.has(id)) continue

--- a/src/WebChannel.js
+++ b/src/WebChannel.js
@@ -157,25 +157,25 @@ class WebChannel {
      * Is the event handler called when a new peer has  joined the `WebChannel`.
      * @type {function(id: number)}
      */
-    this.onPeerJoin = id => {}
+    this.onPeerJoin = () => {}
 
     /**
      * Is the event handler called when a peer hes left the `WebChannel`.
      * @type {function(id: number)}
      */
-    this.onPeerLeave = id => {}
+    this.onPeerLeave = () => {}
 
     /**
      * Is the event handler called when a message is available on the `WebChannel`.
      * @type {function(id: number, msg: UserMessage, isBroadcast: boolean)}
      */
-    this.onMessage = (id, msg, isBroadcast) => {}
+    this.onMessage = () => {}
 
     /**
      * Is the event handler called when the `WebChannel` has been closed.
      * @type {function(closeEvt: CloseEvent)}
      */
-    this.onClose = closeEvt => {}
+    this.onClose = () => {}
   }
 
   /**
@@ -183,7 +183,7 @@ class WebChannel {
    *
    * @param  {string|WebSocket} keyOrSocket The key provided by one of the `WebChannel` members or a socket
    * @param  {string} [url=this.settings.signalingURL] Server URL
-   * @returns {Promise<, string>} It resolves once you became a `WebChannel` member.
+   * @returns {Promise<undefined,string>} It resolves once you became a `WebChannel` member.
    */
   join (keyOrSocket, url = this.settings.signalingURL) {
     return new Promise((resolve, reject) => {
@@ -228,7 +228,7 @@ class WebChannel {
    *
    * @param {string|WebSocket} keyOrSocket
    *
-   * @returns {Promise<, string>}
+   * @returns {Promise<undefined,string>}
    */
   invite (keyOrSocket) {
     if (typeof keyOrSocket === 'string' || keyOrSocket instanceof String) {
@@ -352,7 +352,7 @@ class WebChannel {
    * @private
    * @param {WebSocket|RTCDataChannel} channel
    *
-   * @returns {Promise<, string>}
+   * @returns {Promise<undefined,string>}
    */
   addChannel (channel) {
     return this.initChannel(channel)
@@ -388,9 +388,10 @@ class WebChannel {
    * Send a message to a service of the same peer, joining peer or any peer in
    * the `WebChannel`.
    * @private
-   * @param  {string} serviceId - Service id
-   * @param  {string} recepient - Identifier of recepient peer id
-   * @param  {Object} [msg={}] - Message to send
+   * @param {number} recepient - Identifier of recepient peer id
+   * @param {string} serviceId - Service id
+   * @param {Object} data - Message to send
+   * @param {boolean} [forward=false] - SHould the message be forwarded?
    */
   sendInnerTo (recepient, serviceId, data, forward = false) {
     if (forward) {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import {WEB_SOCKET, WEB_RTC, FULLY_CONNECTED} from 'ServiceFactory'
  * @returns {WebChannel}
  */
 function create (options) {
-  let defaultSettings = {
+  const defaultSettings = {
     connector: WEB_RTC,
     topology: FULLY_CONNECTED,
     signalingURL: 'wss://sigver-coastteam.rhcloud.com:8443',
@@ -24,7 +24,7 @@ function create (options) {
     ],
     listenOn: ''
   }
-  let mySettings = Object.assign({}, defaultSettings, options)
+  const mySettings = Object.assign({}, defaultSettings, options)
   return new WebChannel(mySettings)
 }
 

--- a/src/service/ChannelBuilderService.js
+++ b/src/service/ChannelBuilderService.js
@@ -53,8 +53,8 @@ class ChannelBuilderService extends Service {
    * @returns {{listenOn: string, connectors: number[]}}
    */
   availableConnectors (wc) {
-    let res = {}
-    let connectors = []
+    const res = {}
+    const connectors = []
     if (webRTCAvailable) connectors[connectors.length] = WEB_RTC
     if (wc.settings.listenOn !== '') {
       connectors[connectors.length] = WEB_SOCKET
@@ -75,7 +75,7 @@ class ChannelBuilderService extends Service {
   onChannel (wc, channel, senderId) {
     wc.initChannel(channel, senderId)
       .then(channel => {
-        let pendReq = super.getPendingRequest(wc, senderId)
+        const pendReq = super.getPendingRequest(wc, senderId)
         if (pendReq !== null) pendReq.resolve(channel)
       })
   }
@@ -87,9 +87,9 @@ class ChannelBuilderService extends Service {
    * @param {Object} msg
    */
   onMessage (channel, senderId, recepientId, msg) {
-    let wc = channel.webChannel
-    let myConnectObj = this.availableConnectors(wc)
-    let myConnectors = myConnectObj.connectors
+    const wc = channel.webChannel
+    const myConnectObj = this.availableConnectors(wc)
+    const myConnectors = myConnectObj.connectors
 
     if ('failedReason' in msg) {
       super.getPendingRequest(wc, senderId).reject(msg.failedReason)

--- a/src/service/MessageBuilderService.js
+++ b/src/service/MessageBuilderService.js
@@ -2,7 +2,7 @@ import Util from 'Util'
 import Service from 'service/Service'
 import {USER_DATA} from 'WebChannel'
 
-let src = Util.isBrowser() ? window : require('text-encoding')
+const src = Util.isBrowser() ? window : require('text-encoding')
 const TextEncoder = src.TextEncoder
 const TextDecoder = src.TextDecoder
 
@@ -132,27 +132,27 @@ class MessageBuilderService extends Service {
    * sent to all `WebChannel` members and false if only to one member
    */
   handleUserMessage (data, senderId, recipientId, action, isBroadcast = true) {
-    let workingData = this.userDataToType(data)
-    let dataUint8Array = workingData.content
+    const workingData = this.userDataToType(data)
+    const dataUint8Array = workingData.content
     if (dataUint8Array.byteLength <= MAX_USER_MSG_SIZE) {
-      let dataView = this.initHeader(1, senderId, recipientId,
+      const dataView = this.initHeader(1, senderId, recipientId,
         dataUint8Array.byteLength + USER_MSG_OFFSET
       )
       dataView.setUint32(HEADER_OFFSET, dataUint8Array.byteLength)
       dataView.setUint8(13, workingData.type)
       dataView.setUint8(14, isBroadcast ? 1 : 0)
-      let resultUint8Array = new Uint8Array(dataView.buffer)
+      const resultUint8Array = new Uint8Array(dataView.buffer)
       resultUint8Array.set(dataUint8Array, USER_MSG_OFFSET)
       action(resultUint8Array.buffer)
     } else {
       const msgId = Math.ceil(Math.random() * MAX_MSG_ID_SIZE)
       const totalChunksNb = Math.ceil(dataUint8Array.byteLength / MAX_USER_MSG_SIZE)
       for (let chunkNb = 0; chunkNb < totalChunksNb; chunkNb++) {
-        let currentChunkMsgByteLength = Math.min(
+        const currentChunkMsgByteLength = Math.min(
           MAX_USER_MSG_SIZE,
           dataUint8Array.byteLength - MAX_USER_MSG_SIZE * chunkNb
         )
-        let dataView = this.initHeader(
+        const dataView = this.initHeader(
           USER_DATA,
           senderId,
           recipientId,
@@ -163,10 +163,10 @@ class MessageBuilderService extends Service {
         dataView.setUint8(14, isBroadcast ? 1 : 0)
         dataView.setUint16(15, msgId)
         dataView.setUint16(17, chunkNb)
-        let resultUint8Array = new Uint8Array(dataView.buffer)
+        const resultUint8Array = new Uint8Array(dataView.buffer)
         let j = USER_MSG_OFFSET
-        let startIndex = MAX_USER_MSG_SIZE * chunkNb
-        let endIndex = startIndex + currentChunkMsgByteLength
+        const startIndex = MAX_USER_MSG_SIZE * chunkNb
+        const endIndex = startIndex + currentChunkMsgByteLength
         for (let i = startIndex; i < endIndex; i++) {
           resultUint8Array[j++] = dataUint8Array[i]
         }
@@ -186,10 +186,10 @@ class MessageBuilderService extends Service {
    * @returns {ArrayBuffer} - Built message
    */
   msg (code, senderId = null, recepientId = null, data = {}) {
-    let msgEncoded = (new TextEncoder()).encode(JSON.stringify(data))
-    let msgSize = msgEncoded.byteLength + HEADER_OFFSET
-    let dataView = this.initHeader(code, senderId, recepientId, msgSize)
-    let fullMsg = new Uint8Array(dataView.buffer)
+    const msgEncoded = (new TextEncoder()).encode(JSON.stringify(data))
+    const msgSize = msgEncoded.byteLength + HEADER_OFFSET
+    const dataView = this.initHeader(code, senderId, recepientId, msgSize)
+    const fullMsg = new Uint8Array(dataView.buffer)
     fullMsg.set(msgEncoded, HEADER_OFFSET)
     return fullMsg.buffer
   }
@@ -203,14 +203,14 @@ class MessageBuilderService extends Service {
    * @param {function(msg: UserMessage, isBroadcast: boolean)} action Callback when the message is ready
    */
   readUserMessage (wc, senderId, data, action) {
-    let dataView = new DataView(data)
-    let msgSize = dataView.getUint32(HEADER_OFFSET)
-    let dataType = dataView.getUint8(13)
-    let isBroadcast = dataView.getUint8(14)
+    const dataView = new DataView(data)
+    const msgSize = dataView.getUint32(HEADER_OFFSET)
+    const dataType = dataView.getUint8(13)
+    const isBroadcast = dataView.getUint8(14)
     if (msgSize > MAX_USER_MSG_SIZE) {
-      let msgId = dataView.getUint16(15)
-      let chunk = dataView.getUint16(17)
-      let buffer = this.getBuffer(wc, senderId, msgId)
+      const msgId = dataView.getUint16(15)
+      const chunk = dataView.getUint16(17)
+      const buffer = this.getBuffer(wc, senderId, msgId)
       if (buffer === undefined) {
         this.setBuffer(wc, senderId, msgId,
           new Buffer(msgSize, data, chunk, fullData => {
@@ -221,8 +221,8 @@ class MessageBuilderService extends Service {
         buffer.add(data, chunk)
       }
     } else {
-      let dataArray = new Uint8Array(data)
-      let userData = new Uint8Array(data.byteLength - USER_MSG_OFFSET)
+      const dataArray = new Uint8Array(data)
+      const userData = new Uint8Array(data.byteLength - USER_MSG_OFFSET)
       let j = USER_MSG_OFFSET
       for (let i = 0; i < userData.byteLength; i++) {
         userData[i] = dataArray[j++]
@@ -237,7 +237,7 @@ class MessageBuilderService extends Service {
    * @returns {Object}
    */
   readInternalMessage (data) {
-    let uInt8Array = new Uint8Array(data)
+    const uInt8Array = new Uint8Array(data)
     return JSON.parse((new TextDecoder())
       .decode(uInt8Array.subarray(HEADER_OFFSET, uInt8Array.byteLength))
     )
@@ -250,7 +250,7 @@ class MessageBuilderService extends Service {
    * @returns {MessageHeader}
    */
   readHeader (data) {
-    let dataView = new DataView(data)
+    const dataView = new DataView(data)
     return {
       code: dataView.getUint8(0),
       senderId: dataView.getUint32(1),
@@ -268,7 +268,7 @@ class MessageBuilderService extends Service {
    * @return {DataView} Data view with initialized header
    */
   initHeader (code, senderId, recipientId, dataSize) {
-    let dataView = new DataView(new ArrayBuffer(dataSize))
+    const dataView = new DataView(new ArrayBuffer(dataSize))
     dataView.setUint8(0, code)
     dataView.setUint32(1, senderId)
     dataView.setUint32(5, recipientId)
@@ -318,7 +318,7 @@ class MessageBuilderService extends Service {
    * @returns {MessageTypeEnum} User message type
    */
   userDataToType (data) {
-    let result = {}
+    const result = {}
     if (data instanceof ArrayBuffer) {
       result.type = ARRAY_BUFFER_TYPE
       result.content = new Uint8Array(data)
@@ -362,9 +362,9 @@ class MessageBuilderService extends Service {
    * @returns {Buffer|undefined} Returns buffer if it was found and undefined if not
    */
   getBuffer (wc, peerId, msgId) {
-    let wcBuffer = buffers.get(wc)
+    const wcBuffer = buffers.get(wc)
     if (wcBuffer !== undefined) {
-      let peerBuffer = wcBuffer.get(peerId)
+      const peerBuffer = wcBuffer.get(peerId)
       if (peerBuffer !== undefined) {
         return peerBuffer.get(msgId)
       }
@@ -423,8 +423,8 @@ class Buffer {
    * @param {number} chunkNb - Number of the chunk
    */
   add (data, chunkNb) {
-    let dataChunk = new Uint8Array(data)
-    let dataChunkSize = data.byteLength
+    const dataChunk = new Uint8Array(data)
+    const dataChunkSize = data.byteLength
     this.currentSize += dataChunkSize - USER_MSG_OFFSET
     let index = chunkNb * MAX_USER_MSG_SIZE
     for (let i = USER_MSG_OFFSET; i < dataChunkSize; i++) {

--- a/src/service/MessageBuilderService.js
+++ b/src/service/MessageBuilderService.js
@@ -279,7 +279,7 @@ class MessageBuilderService extends Service {
    * Netflux sends data in `ArrayBuffer`, but the user can send data in different
    * types. This function retrieve the inital message sent by the user.
    * @private
-   * @param {ArrayBuffer} Message as it was received by the `WebChannel`
+   * @param {ArrayBuffer} buffer Message as it was received by the `WebChannel`
    * @param {MessageTypeEnum} type Message type as it was defined by the user
    * @returns {ArrayBuffer|TypedArray} Initial user message
    */
@@ -314,7 +314,7 @@ class MessageBuilderService extends Service {
    * Identify the user message type.
    *
    * @private
-   * @param {UserMessage} User message
+   * @param {UserMessage} data User message
    * @returns {MessageTypeEnum} User message type
    */
   userDataToType (data) {
@@ -406,7 +406,8 @@ class Buffer {
 
   /**
    * @param {number} fullDataSize The total user message size
-   * @param {ArrayBuffer} The first chunk of the user message
+   * @param {ArrayBuffer} data The first chunk of the user message
+   * @param {number} chunkNb Number of the chunk
    * @param {function(buffer: ArrayBuffer)} action Callback to be executed when all
    * message chunks are received and thus the message is ready
    */

--- a/src/service/MessageBuilderService.js
+++ b/src/service/MessageBuilderService.js
@@ -307,6 +307,8 @@ class MessageBuilderService extends Service {
         return new Float32Array(buffer)
       case FLOAT_64_ARRAY_TYPE:
         return new Float64Array(buffer)
+      default:
+        throw new Error('Unknown type')
     }
   }
 

--- a/src/service/Service.js
+++ b/src/service/Service.js
@@ -90,7 +90,7 @@ class Service {
    * @returns {Map}
    */
   getItems (obj) {
-    let items = itemsStorage.get(this.id).get(obj)
+    const items = itemsStorage.get(this.id).get(obj)
     if (items) return items
     else return new Map()
   }
@@ -102,8 +102,8 @@ class Service {
    * @param {number} id
    */
   removeItem (obj, id) {
-    let currentServiceTemp = itemsStorage.get(this.id)
-    let idMap = currentServiceTemp.get(obj)
+    const currentServiceTemp = itemsStorage.get(this.id)
+    const idMap = currentServiceTemp.get(obj)
     currentServiceTemp.get(obj).delete(id)
     if (idMap.size === 0) currentServiceTemp.delete(obj)
   }
@@ -117,9 +117,9 @@ class Service {
    * @returns {Object}
    */
   getFrom (storage, obj, id) {
-    let idMap = storage.get(this.id).get(obj)
+    const idMap = storage.get(this.id).get(obj)
     if (idMap !== undefined) {
-      let item = idMap.get(id)
+      const item = idMap.get(id)
       if (item !== undefined) return item
     }
     return null
@@ -134,7 +134,7 @@ class Service {
    *
    */
   setTo (storage, obj, id, data) {
-    let currentServiceTemp = storage.get(this.id)
+    const currentServiceTemp = storage.get(this.id)
     let idMap
     if (currentServiceTemp.has(obj)) {
       idMap = currentServiceTemp.get(obj)

--- a/src/service/WebRTCService.js
+++ b/src/service/WebRTCService.js
@@ -51,7 +51,7 @@ class WebRTCService extends Service {
    * @param {Object} msg
    */
   onMessage (channel, senderId, recepientId, msg) {
-    let wc = channel.webChannel
+    const wc = channel.webChannel
     let item = super.getItem(wc, senderId)
     if (!item) {
       item = new CandidatesBuffer()
@@ -86,7 +86,7 @@ class WebRTCService extends Service {
    * @returns {Promise<RTCDataChannel, string>}
    */
   connectOverWebChannel (wc, id) {
-    let item = new CandidatesBuffer(this.createPeerConnection(candidate => {
+    const item = new CandidatesBuffer(this.createPeerConnection(candidate => {
       wc.sendInnerTo(id, this.id, {candidate})
     }))
     super.setItem(wc, id, item)
@@ -110,7 +110,7 @@ class WebRTCService extends Service {
    */
   listenFromSignaling (ws, onChannel) {
     ws.onmessage = evt => {
-      let msg = JSON.parse(evt.data)
+      const msg = JSON.parse(evt.data)
       if ('id' in msg && 'data' in msg) {
         let item = super.getItem(ws, msg.id)
         if (!item) {
@@ -146,7 +146,7 @@ class WebRTCService extends Service {
    * @returns {type} Description
    */
   connectOverSignaling (ws, key) {
-    let item = new CandidatesBuffer(this.createPeerConnection(candidate => {
+    const item = new CandidatesBuffer(this.createPeerConnection(candidate => {
       if (ws.readyState === 1) ws.send(JSON.stringify({data: {candidate}}))
     }))
     super.setItem(ws, key, item)
@@ -154,7 +154,7 @@ class WebRTCService extends Service {
       ws.onclose = closeEvt => reject(closeEvt.reason)
       ws.onmessage = evt => {
         try {
-          let msg = JSON.parse(evt.data)
+          const msg = JSON.parse(evt.data)
           if ('data' in msg) {
             if ('answer' in msg.data) {
               item.pc.setRemoteDescription(msg.data.answer)
@@ -232,7 +232,7 @@ class WebRTCService extends Service {
    * @return {RTCPeerConnection}
    */
   createPeerConnection (onCandidate) {
-    let pc = new RTCPeerConnection({iceServers: this.iceServers})
+    const pc = new RTCPeerConnection({iceServers: this.iceServers})
     pc.isRemoteDescriptionSet = false
     pc.addReceivedCandidates = candidates => {
       pc.isRemoteDescriptionSet = true
@@ -240,7 +240,7 @@ class WebRTCService extends Service {
     }
     pc.onicecandidate = evt => {
       if (evt.candidate !== null) {
-        let candidate = {
+        const candidate = {
           candidate: evt.candidate.candidate,
           sdpMid: evt.candidate.sdpMid,
           sdpMLineIndex: evt.candidate.sdpMLineIndex
@@ -259,7 +259,7 @@ class WebRTCService extends Service {
    *
    */
   createDataChannel (pc, onOpen) {
-    let dc = pc.createDataChannel(null)
+    const dc = pc.createDataChannel(null)
     dc.onopen = evt => onOpen(dc)
     this.setUpOnDisconnect(pc, dc)
   }

--- a/src/service/WebRTCService.js
+++ b/src/service/WebRTCService.js
@@ -202,11 +202,11 @@ class WebRTCService extends Service {
    * Creates an SDP answer.
    *
    * @private
-   * @param  {RTCPeerConnection} pc
-   * @param  {string} offer
-   * @param  {Array[string]} candidates
-   * @return {Promise<RTCSessionDescription, string>} - Resolved when the offer has been succesfully created,
-   * set as local description and sent to the peer.
+   * @param {RTCPeerConnection} pc
+   * @param {string} offer
+   * @param {string[]} candidates
+   * @return {Promise<RTCSessionDescription, string>} - Resolved when the offer
+   *  has been succesfully created, set as local description and sent to the peer.
    */
   createAnswer (pc, offer, candidates) {
     return pc.setRemoteDescription(offer)
@@ -282,8 +282,6 @@ class WebRTCService extends Service {
    * @private
    * @param {RTCPeerConnection} pc
    * @param {RTCDataChannel} dataCh
-   *
-   * @returns {type} Description
    */
   setUpOnDisconnect (pc, dataCh) {
     pc.oniceconnectionstatechange = () => {
@@ -297,8 +295,6 @@ class WebRTCService extends Service {
    * @private
    * @param {CandidatesBuffer|null} obj
    * @param {string} candidate
-   *
-   * @returns {type} Description
    */
   addIceCandidate (obj, candidate) {
     if (obj !== null && obj.pc && obj.pc.isRemoteDescriptionSet) {

--- a/src/service/WebSocketService.js
+++ b/src/service/WebSocketService.js
@@ -25,7 +25,7 @@ class WebSocketService extends Service {
   connect (url) {
     return new Promise((resolve, reject) => {
       try {
-        let ws = new WebSocket(url)
+        const ws = new WebSocket(url)
         ws.onopen = () => resolve(ws)
         // Timeout for node (otherwise it will loop forever if incorrect address)
         setTimeout(() => {

--- a/src/service/topology/FullyConnectedService.js
+++ b/src/service/topology/FullyConnectedService.js
@@ -37,8 +37,8 @@ class FullyConnectedService extends TopologyInterface {
    * @returns {Promise<number, string}
    */
   add (channel) {
-    let wc = channel.webChannel
-    let peers = wc.members.slice()
+    const wc = channel.webChannel
+    const peers = wc.members.slice()
     for (let jpId of super.getItems(wc).keys()) peers[peers.length] = jpId
     this.setJP(wc, channel.peerId, channel)
     wc.sendInner(this.id, {code: SHOULD_ADD_NEW_JOINING_PEER, jpId: channel.peerId})
@@ -83,7 +83,7 @@ class FullyConnectedService extends TopologyInterface {
   }
 
   sendInner (wc, data) {
-    let jp = super.getItem(wc, wc.myId)
+    const jp = super.getItem(wc, wc.myId)
     if (jp === null) this.broadcast(wc, data)
     else jp.channel.send(data)
   }
@@ -114,11 +114,11 @@ class FullyConnectedService extends TopologyInterface {
   onChannelClose (closeEvt, channel) {
     // TODO: need to check if this is a peer leaving and thus he closed channels
     // with all WebChannel members or this is abnormal channel closing
-    let wc = channel.webChannel
+    const wc = channel.webChannel
     for (let c of wc.channels) {
       if (c.peerId === channel.peerId) return wc.channels.delete(c)
     }
-    let jps = super.getItems(wc)
+    const jps = super.getItems(wc)
     jps.forEach(jp => jp.channels.delete(channel))
     return false
   }
@@ -134,7 +134,7 @@ class FullyConnectedService extends TopologyInterface {
   }
 
   onMessage (channel, senderId, recepientId, msg) {
-    let wc = channel.webChannel
+    const wc = channel.webChannel
     let jpMe
     switch (msg.code) {
       case SHOULD_CONNECT_TO:
@@ -142,7 +142,7 @@ class FullyConnectedService extends TopologyInterface {
         jpMe.channels.add(channel)
         super.connectTo(wc, msg.peers)
           .then(failed => {
-            let msg = {code: PEER_JOINED}
+            const msg = {code: PEER_JOINED}
             jpMe.channels.forEach(ch => {
               wc.sendInnerTo(ch, this.id, msg)
               wc.channels.add(ch)
@@ -160,13 +160,13 @@ class FullyConnectedService extends TopologyInterface {
         else {
           wc.channels.add(channel)
           wc.onPeerJoin$(senderId)
-          let request = super.getPendingRequest(wc, senderId)
+          const request = super.getPendingRequest(wc, senderId)
           if (request !== null) request.resolve(senderId)
         }
         break
       case TICK:
         this.setJP(wc, senderId, channel)
-        let isJoining = super.getItem(wc, wc.myId) !== null
+        const isJoining = super.getItem(wc, wc.myId) !== null
         wc.sendInnerTo(channel, this.id, {code: TOCK, isJoining})
         break
       case TOCK:

--- a/src/service/topology/FullyConnectedService.js
+++ b/src/service/topology/FullyConnectedService.js
@@ -34,7 +34,7 @@ class FullyConnectedService extends TopologyInterface {
    *
    * @param {WebSocket|RTCDataChannel} channel
    *
-   * @returns {Promise<number, string}
+   * @returns {Promise<number, string>}
    */
   add (channel) {
     const wc = channel.webChannel

--- a/src/service/topology/FullyConnectedService.js
+++ b/src/service/topology/FullyConnectedService.js
@@ -164,11 +164,12 @@ class FullyConnectedService extends TopologyInterface {
           if (request !== null) request.resolve(senderId)
         }
         break
-      case TICK:
+      case TICK: {
         this.setJP(wc, senderId, channel)
         const isJoining = super.getItem(wc, wc.myId) !== null
         wc.sendInnerTo(channel, this.id, {code: TOCK, isJoining})
         break
+      }
       case TOCK:
         if (msg.isJoining) this.setJP(wc, senderId, channel)
         else super.getItem(wc, wc.myId).channels.add(channel)

--- a/src/service/topology/TopologyInterface.js
+++ b/src/service/topology/TopologyInterface.js
@@ -17,12 +17,12 @@ import ServiceFactory, {CHANNEL_BUILDER} from 'ServiceFactory'
 class TopologyInterface extends Service {
 
   connectTo (wc, peerIds) {
-    let failed = []
+    const failed = []
     if (peerIds.length === 0) return Promise.resolve(failed)
     else {
       return new Promise((resolve, reject) => {
         let counter = 0
-        let cBuilder = ServiceFactory.get(CHANNEL_BUILDER)
+        const cBuilder = ServiceFactory.get(CHANNEL_BUILDER)
         peerIds.forEach(id => {
           cBuilder.connectTo(wc, id)
             .then(channel => this.onChannel(channel))

--- a/test/functional/fullyConnected/1peer.test.js
+++ b/test/functional/fullyConnected/1peer.test.js
@@ -2,7 +2,7 @@ import {create} from 'src/index'
 import {SIGNALING_URL} from 'util/helper'
 
 describe('🙂', () => {
-  let wc = create({signalingURL: SIGNALING_URL})
+  const wc = create({signalingURL: SIGNALING_URL})
   it('Should construct a WebChannel', () => {
     expect(wc.id).not.toBeNull()
     expect(wc.id).not.toBeUndefined()

--- a/test/functional/fullyConnected/2peers/2humans.test.js
+++ b/test/functional/fullyConnected/2peers/2humans.test.js
@@ -4,8 +4,8 @@ import smallStr from 'util/200kb.txt'
 import bigStr from 'util/4mb.txt'
 
 describe('🙂 🙂  fully connected', () => {
-  let signalingURL = helper.SIGNALING_URL
-  let wcs = []
+  const signalingURL = helper.SIGNALING_URL
+  const wcs = []
 
   it('Should establish a connection', done => {
     wcs[0] = create({signalingURL})
@@ -59,7 +59,7 @@ describe('🙂 🙂  fully connected', () => {
     }
 
     it('~200 KB string', done => {
-      let groups = []
+      const groups = []
       for (let i = 0; i < 2; i++) {
         groups[i] = new helper.TestGroup(wcs[i], null)
         groups[i].set(String, smallStr + i)
@@ -70,8 +70,8 @@ describe('🙂 🙂  fully connected', () => {
     })
 
     helper.itBrowser(true, '~4 MB string', done => {
-      let index1 = Math.round(Math.random())
-      let index2 = 1 - index1
+      const index1 = Math.round(Math.random())
+      const index2 = 1 - index1
       wcs[index1].onMessage = (id, msg) => {
         expect(id).toEqual(wcs[index2].myId)
         expect(msg === bigStr).toBeTruthy()
@@ -81,15 +81,15 @@ describe('🙂 🙂  fully connected', () => {
     }, 10000)
 
     it(`${helper.MSG_NUMBER} small messages`, done => {
-      let msgArray1 = []
-      let msgArray2 = []
-      let msgArrays = [msgArray1, msgArray2]
-      let nb = Math.floor(helper.MSG_NUMBER / 3)
+      const msgArray1 = []
+      const msgArray2 = []
+      const msgArrays = [msgArray1, msgArray2]
+      const nb = Math.floor(helper.MSG_NUMBER / 3)
       for (let i = 0; i < nb; i++) {
         msgArray1[i] = helper.randStr()
         msgArray2[i] = helper.randStr()
       }
-      let startSend = index => new Promise((resolve, reject) => {
+      const startSend = index => new Promise((resolve, reject) => {
         for (let e of msgArrays[index]) wcs[index].send(e)
         resolve()
       })
@@ -171,7 +171,7 @@ describe('🙂 🙂  fully connected', () => {
 
   it('Should not be able to join the WebChannel after it has been closed', done => {
     expect(wcs[0].isOpen()).toBeTruthy()
-    let key = wcs[0].getOpenData().key
+    const key = wcs[0].getOpenData().key
     wcs[0].close()
     wcs[1].join(key).then(done.fail).catch(done)
   })

--- a/test/functional/fullyConnected/2peers/botHuman.test.js
+++ b/test/functional/fullyConnected/2peers/botHuman.test.js
@@ -4,7 +4,7 @@ import smallStr from 'util/200kb.txt'
 import bigStr from 'util/4mb.txt'
 
 describe('🤖 🙂  fully connected', () => {
-  let signalingURL = helper.SIGNALING_URL
+  const signalingURL = helper.SIGNALING_URL
   let wc
 
   it('Should establish a connection through data channel', done => {
@@ -24,13 +24,13 @@ describe('🤖 🙂  fully connected', () => {
 
   describe('Should send/receive', () => {
     it('Private string message', done => {
-      let data = helper.randData(String)
+      const data = helper.randData(String)
       helper.sendReceive(wc, data, done, wc.members[0])
     })
 
     for (let i of helper.INSTANCES) {
       it('broadcast: ' + i.prototype.constructor.name, done => {
-        let data = helper.randData(i)
+        const data = helper.randData(i)
         helper.sendReceive(wc, data, done)
       })
     }
@@ -44,13 +44,13 @@ describe('🤖 🙂  fully connected', () => {
     }, 10000)
 
     it(`${helper.MSG_NUMBER} small messages`, done => {
-      let data = []
-      let dataReceived = Array(helper.MSG_NUMBER)
+      const data = []
+      const dataReceived = Array(helper.MSG_NUMBER)
       for (let i = 0; i < helper.MSG_NUMBER; i++) data[i] = helper.randData(String)
       dataReceived.fill(0)
       wc.onMessage = (id, msg, isBroadcast) => {
         expect(typeof msg).toEqual('string')
-        let index = data.indexOf(msg)
+        const index = data.indexOf(msg)
         expect(index).not.toEqual(-1)
         expect(dataReceived[index]++).toEqual(0)
         expect(isBroadcast).toBeTruthy()

--- a/test/functional/fullyConnected/2peers/humanBot.test.js
+++ b/test/functional/fullyConnected/2peers/humanBot.test.js
@@ -4,7 +4,7 @@ import smallStr from 'util/200kb.txt'
 import bigStr from 'util/4mb.txt'
 
 describe('🙂 🤖  fully connected', () => {
-  let signalingURL = helper.SIGNALING_URL
+  const signalingURL = helper.SIGNALING_URL
   let wc
 
   it('Should establish a connection through socket', done => {
@@ -22,13 +22,13 @@ describe('🙂 🤖  fully connected', () => {
 
   describe('Should send/receive', () => {
     it('Private string message', done => {
-      let data = helper.randData(String)
+      const data = helper.randData(String)
       helper.sendReceive(wc, data, done, wc.members[0])
     })
 
     for (let i of helper.INSTANCES) {
       it('broadcast: ' + i.prototype.constructor.name, done => {
-        let data = helper.randData(i)
+        const data = helper.randData(i)
         helper.sendReceive(wc, data, done)
       })
     }
@@ -42,13 +42,13 @@ describe('🙂 🤖  fully connected', () => {
     }, 10000)
 
     it(`${helper.MSG_NUMBER} small messages`, done => {
-      let data = []
-      let dataReceived = Array(helper.MSG_NUMBER)
+      const data = []
+      const dataReceived = Array(helper.MSG_NUMBER)
       for (let i = 0; i < helper.MSG_NUMBER; i++) data[i] = helper.randData(String)
       dataReceived.fill(0)
       wc.onMessage = (id, msg, isBroadcast) => {
         expect(typeof msg).toEqual('string')
-        let index = data.indexOf(msg)
+        const index = data.indexOf(msg)
         expect(index).not.toEqual(-1)
         expect(dataReceived[index]++).toEqual(0)
         expect(isBroadcast).toBeTruthy()

--- a/test/functional/fullyConnected/3peers/3humans.test.js
+++ b/test/functional/fullyConnected/3peers/3humans.test.js
@@ -4,8 +4,8 @@ import smallStr from 'util/200kb.txt'
 import bigStr from 'util/4mb.txt'
 
 describe('Fully connected: 3 peers', () => {
-  let signalingURL = helper.SIGNALING_URL
-  let wcs = []
+  const signalingURL = helper.SIGNALING_URL
+  const wcs = []
   afterAll(() => {
     wcs[0].leave()
     wcs[1].leave()
@@ -14,8 +14,8 @@ describe('Fully connected: 3 peers', () => {
 
   describe('Should establish a connection', () => {
     function* checkJoining (resolve, wc) {
-      let id1 = yield
-      let id2 = yield
+      const id1 = yield
+      const id2 = yield
       expect(id1).not.toEqual(id2)
       for (let e of wcs) {
         if (e.myId !== wc.myId) {
@@ -24,8 +24,8 @@ describe('Fully connected: 3 peers', () => {
       }
       resolve()
     }
-    let allJoiningDetectedBy = wc => new Promise((resolve, reject) => {
-      let gen = checkJoining(resolve, wc)
+    const allJoiningDetectedBy = wc => new Promise((resolve, reject) => {
+      const gen = checkJoining(resolve, wc)
       gen.next()
       wc.onPeerJoin = id => gen.next(id)
     })
@@ -109,7 +109,7 @@ describe('Fully connected: 3 peers', () => {
     }
 
     helper.itBrowser(true, '~200 KB string', done => {
-      let groups = []
+      const groups = []
       for (let i = 0; i < 3; i++) {
         groups[i] = new helper.TestGroup(wcs[i], null)
         groups[i].set(String, smallStr + i)
@@ -120,10 +120,10 @@ describe('Fully connected: 3 peers', () => {
     })
 
     helper.itBrowser(true, '~4 MB string', done => {
-      let indexes = [0, 1, 2]
-      let index1 = Math.round(2 * Math.random())
+      const indexes = [0, 1, 2]
+      const index1 = Math.round(2 * Math.random())
       indexes.splice(index1, 1)
-      let index2 = indexes[Math.round(Math.random())]
+      const index2 = indexes[Math.round(Math.random())]
       wcs[index1].onMessage = (id, msg) => {
         expect(id).toEqual(wcs[index2].myId)
         expect(msg === bigStr).toBeTruthy()
@@ -133,19 +133,19 @@ describe('Fully connected: 3 peers', () => {
     }, 4000)
 
     it(`${helper.MSG_NUMBER} small messages`, done => {
-      let msgs = []
+      const msgs = []
       for (let i = 0; i < 3; i++) msgs[i] = []
-      let nb = Math.floor(helper.MSG_NUMBER / 3)
+      const nb = Math.floor(helper.MSG_NUMBER / 3)
       for (let i = 0; i < nb; i++) {
         msgs[0][i] = helper.randStr()
         msgs[1][i] = helper.randStr()
         msgs[2][i] = helper.randStr()
       }
-      let startSend = index => new Promise((resolve, reject) => {
+      const startSend = index => new Promise((resolve, reject) => {
         for (let msg of msgs[index]) wcs[index].send(msg)
         resolve()
       })
-      let allMessagesReceived = index => {
+      const allMessagesReceived = index => {
         return new Promise((resolve, reject) => {
           let counter1 = 0
           let counter2 = 0

--- a/test/functional/fullyConnected/3peers/humanBotHuman.test.js
+++ b/test/functional/fullyConnected/3peers/humanBotHuman.test.js
@@ -3,7 +3,7 @@ import * as helper from 'util/helper'
 
 xdescribe('🙂 🤖 🙂  || 🙂 🙂 🤖  fully connected', () => {
   const key = 'humanBotHuman'
-  let signalingURL = helper.SIGNALING_URL
+  const signalingURL = helper.SIGNALING_URL
   let wc
   let botId
 

--- a/test/functional/fullyConnected/manyPeers.test.js
+++ b/test/functional/fullyConnected/manyPeers.test.js
@@ -3,20 +3,20 @@ import * as helper from 'util/helper'
 const NB_PEERS = 12
 
 describe(`Fully connected: many peers (${NB_PEERS})`, () => {
-  let signalingURL = helper.SIGNALING_URL
-  let wcs = []
+  const signalingURL = helper.SIGNALING_URL
+  const wcs = []
 
   describe('Should establish a connection', () => {
     function allJoiningDetectedByAll () {
-      let joined = new Map()
-      let joinPromises = []
+      const joined = new Map()
+      const joinPromises = []
       for (let i = 0; i < NB_PEERS; i++) {
         wcs[i] = create({signalingURL})
         joined.set(i, [])
         if (i !== NB_PEERS - 1) {
           joinPromises.push(new Promise((resolve, reject) => {
             wcs[i].onPeerJoin = id => {
-              let joinedTab = joined.get(i)
+              const joinedTab = joined.get(i)
               expect(joinedTab.includes(id)).toBeFalsy()
               joinedTab.push(id)
               if (joinedTab.length === NB_PEERS - 1) resolve()
@@ -37,8 +37,8 @@ describe(`Fully connected: many peers (${NB_PEERS})`, () => {
         })
         .catch(done.fail)
 
-      let joinOneByOne = function (prom, index, key) {
-        let i = index
+      const joinOneByOne = function (prom, index, key) {
+        const i = index
         if (index === NB_PEERS) return prom
         return joinOneByOne(prom.then(() => wcs[i].join(key)), ++index, key)
       }
@@ -66,7 +66,7 @@ describe(`Fully connected: many peers (${NB_PEERS})`, () => {
 
   describe('Should send/receive', () => {
     helper.itBrowser(false, 'broadcast string message', done => {
-      let groups = []
+      const groups = []
       for (let i = 0; i < NB_PEERS; i++) {
         groups[i] = new helper.TestGroup(wcs[i], [String])
       }

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -1,14 +1,14 @@
-let fs = require('fs')
-let rollup = require('rollup')
-let includePaths = require('rollup-plugin-includepaths')
-let string = require('rollup-plugin-string')
+const fs = require('fs')
+const rollup = require('rollup')
+const includePaths = require('rollup-plugin-includepaths')
+const string = require('rollup-plugin-string')
 
-let entries = []
+const entries = []
 function read (path) {
   if (path.endsWith('test.js')) {
     entries.push(path)
   } else if (fs.statSync(path).isDirectory()) {
-    let items = fs.readdirSync(path)
+    const items = fs.readdirSync(path)
     for (let i of items) {
       read(path + '/' + i)
     }
@@ -17,7 +17,7 @@ function read (path) {
 read('test')
 
 for (let entry of entries) {
-  let dest = entry.replace(/^test/, '.rolledupTest')
+  const dest = entry.replace(/^test/, '.rolledupTest')
   rollup.rollup({
     entry,
     plugins: [

--- a/test/unit/SignalingGate.test.js
+++ b/test/unit/SignalingGate.test.js
@@ -2,14 +2,14 @@ import SignalingGate from 'src/SignalingGate'
 import {SIGNALING_URL} from 'util/helper'
 
 describe('SignalingGate', () => {
-  let FakeWebChannel = class {
+  const FakeWebChannel = class {
     constructor (onClose = () => {}) {
       this.onClose = onClose
       this.settings = {iceServers: {}}
     }
   }
   let signalingGate
-  let signalingURL = SIGNALING_URL
+  const signalingURL = SIGNALING_URL
 
   it('Gate should be closed after construction', () => {
     signalingGate = new SignalingGate(new FakeWebChannel())
@@ -20,15 +20,15 @@ describe('SignalingGate', () => {
   })
 
   it('Should generate different keys', () => {
-    let key1 = signalingGate.generateKey()
-    let key2 = signalingGate.generateKey()
+    const key1 = signalingGate.generateKey()
+    const key2 = signalingGate.generateKey()
     expect(key1).not.toEqual(key2)
   })
 
   it('Should fail to open the gate with the key used by another gate', done => {
-    let key = signalingGate.generateKey()
-    let wcg1 = new SignalingGate(new FakeWebChannel())
-    let wcg2 = new SignalingGate(new FakeWebChannel())
+    const key = signalingGate.generateKey()
+    const wcg1 = new SignalingGate(new FakeWebChannel())
+    const wcg2 = new SignalingGate(new FakeWebChannel())
     wcg1.open(signalingURL, () => {}, key)
       .then(() => {
         wcg2.open(() => {}, key)
@@ -41,7 +41,7 @@ describe('SignalingGate', () => {
   })
 
   describe('Open with auto generated key', () => {
-    let signalingGate = new SignalingGate(new FakeWebChannel())
+    const signalingGate = new SignalingGate(new FakeWebChannel())
     let openData
 
     it('Should open the gate', done => {
@@ -71,7 +71,7 @@ describe('SignalingGate', () => {
     })
 
     it('onClose should be called', done => {
-      let wcg = new SignalingGate(new FakeWebChannel(done))
+      const wcg = new SignalingGate(new FakeWebChannel(done))
       wcg.open(signalingURL, () => {})
         .then(() => { wcg.close() })
         .catch(done.fail)
@@ -79,11 +79,11 @@ describe('SignalingGate', () => {
   })
 
   describe('Open with the specified key', () => {
-    let signalingGate = new SignalingGate(new FakeWebChannel())
+    const signalingGate = new SignalingGate(new FakeWebChannel())
     let openData
 
     it('Should open the gate', done => {
-      let key = signalingGate.generateKey()
+      const key = signalingGate.generateKey()
       signalingGate.open(signalingURL, () => {}, key)
         .then(data => {
           openData = data
@@ -111,8 +111,8 @@ describe('SignalingGate', () => {
     })
 
     it('onClose should be called', done => {
-      let key = signalingGate.generateKey()
-      let wcg = new SignalingGate(new FakeWebChannel(done))
+      const key = signalingGate.generateKey()
+      const wcg = new SignalingGate(new FakeWebChannel(done))
       wcg.open(signalingURL, () => {}, key)
         .then(() => { wcg.close() })
         .catch(done.fail)

--- a/test/unit/service/WebSocketService.test.js
+++ b/test/unit/service/WebSocketService.test.js
@@ -5,7 +5,7 @@ describe('WebSocketService', () => {
   const ONLINE_SECURE_SERVER = 'wss://sigver-coastteam.rhcloud.com:8443'
   const LOCAL_SERVER = 'ws://localhost:8000'
   const WRONG_URL = 'https://github.com:8100/coast-team/netflux'
-  let webSocketService = new WebSocketService()
+  const webSocketService = new WebSocketService()
   let socket = {}
 
   afterEach(() => {

--- a/test/util/helper.js
+++ b/test/util/helper.js
@@ -32,7 +32,7 @@ function randData (Instance) {
     res = randStr()
   } else {
     const lengthBuf = 64 + 64 * Math.ceil(Math.random() * 100)
-    let buffer = new ArrayBuffer(lengthBuf)
+    const buffer = new ArrayBuffer(lengthBuf)
     if (Instance === ArrayBuffer) return buffer
     else if ([Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array].includes(Instance)) {
       res = new Instance(buffer)
@@ -82,7 +82,7 @@ function isEqual (msg1, msg2, Instance) {
 function allMessagesAreSentAndReceived (groups, Instance, isBroadcast = true) {
   return Promise.all(groups.map(
     group => new Promise((resolve, reject) => {
-      let tab = new Map()
+      const tab = new Map()
       for (let g of groups) if (g.wc.myId !== group.wc.myId) tab.set(g.wc.myId, g.get(Instance))
       group.wc.onMessage = (id, msg, isBroadcast) => {
         expect(isBroadcast).toEqual(isBroadcast)
@@ -102,8 +102,8 @@ function checkMembers (wcs) {
     expect(wc.members.length).toEqual(wcs.length - 1)
     for (let wc2 of wcs) {
       if (wc.myId !== wc2.myId) {
-        let firstIndex = wc2.members.indexOf(wc.myId)
-        let lastIndex = wc2.members.lastIndexOf(wc.myId)
+        const firstIndex = wc2.members.indexOf(wc.myId)
+        const lastIndex = wc2.members.lastIndexOf(wc.myId)
         expect(firstIndex).not.toEqual(-1)
         expect(firstIndex).toEqual(lastIndex)
       }
@@ -165,7 +165,7 @@ function xitNode (shouldSkip, ...args) {
 
 function env () {
   if (Util.isBrowser()) {
-    let sUsrAg = navigator.userAgent
+    const sUsrAg = navigator.userAgent
     if (sUsrAg.indexOf('Chrome') > -1) {
       return 'CHROME'
     } else if (sUsrAg.indexOf('Firefox') > -1) {
@@ -192,7 +192,7 @@ function sendReceive (wc, data, done, id) {
 
 function onMessageForBot (wc, id, msg, isBroadcast) {
   try {
-    let data = JSON.parse(msg)
+    const data = JSON.parse(msg)
     switch (data.code) {
       case LEAVE_CODE:
         wc.leave()

--- a/test/util/helper.js
+++ b/test/util/helper.js
@@ -37,14 +37,14 @@ function randData (Instance) {
     else if ([Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array].includes(Instance)) {
       res = new Instance(buffer)
       let sign = -1
-      for (let i in res) {
+      for (let i of res) {
         res[i] = Math.round(Math.random() * 255) * sign
         sign *= sign
       }
     } else if ([Float32Array, Float64Array].includes(Instance)) {
       res = new Instance(buffer)
       let sign = -1
-      for (let i in res) {
+      for (let i of res) {
         res[i] = Math.random() * 255 * sign
         sign *= sign
       }


### PR DESCRIPTION
Hi!

The PR adds a new linter (See #18), apply the needed fixes and add a lint command:

``` bash
npm run lint
```

Some rules are disabled. They should be enabled later. This includes:
- "prefer-const" because Firefox does not support yet the `const` keyword in for-in/for-of loops
- ""no-sync" since build scripts use sync functions.
